### PR TITLE
Add link to source of truth (SharePoint) in automated PR body

### DIFF
--- a/.github/workflows/update-runtime_setting.yml
+++ b/.github/workflows/update-runtime_setting.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Update runtime_setting.yaml
         run: ./.github/scripts/generate-runtime-config
+        env:
+          INPUT_FILE: ./members-payload.json
+          OUTPUT_FILE: ./runtime_setting.yaml
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Body of future automated will look exactly like the one [here](https://github.com/ed-tech-lab/Lobot/pull/8), with a link to [GPU Cluster Users](https://queensuca.sharepoint.com/teams/GROUP-QSCSystemsStaff/Lists/Users/Groups.aspx), which is the SSoT for the values in [runtime_setting.yaml](https://github.com/Queens-School-of-Computing/Lobot/blob/f71d30487543ca751f59b02f6b3a203baa047c05/runtime_setting.yaml)

While here, add a more descriptive branch name, and use environment variables (just to demonstrate the affordance, for future refactors).